### PR TITLE
[UPDATE] Desabilita a compressão dos arquivos JS.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,6 @@ const config = require("konfig")({ path: "." });
 const cssnano = require("gulp-cssnano");
 const htmlmin = require("gulp-htmlmin");
 const bro = require("gulp-bro");
-const gzip = require("gulp-gzip");
 
 // Where our files are located
 const paths = {
@@ -173,7 +172,6 @@ gulp.task("build", ["html", "browserify", "angular-bootstrap-calendarCss", "mate
     .pipe(sourcemaps.init({ loadMaps: true }))
     .pipe(uglify())
     .pipe(sourcemaps.write("./"))
-    .pipe(gzip())
     .pipe(gulp.dest(paths.distDest));
 
   const css = gulp.src(`${paths.buildDest}css/**`)


### PR DESCRIPTION
Desabilita a compressão dos arquivos JS pois o nginx de produção já compacta os arquivos a cada requisição.